### PR TITLE
Support for Pulsar 1.5

### DIFF
--- a/exporter.json
+++ b/exporter.json
@@ -3,7 +3,7 @@
     "name": "Flutter",
     "description": "Flutter token and style exporter",
     "source_dir": "src",
-    "version": "1.0.4",
+    "version": "1.1",
     "tags": [
         "Flutter",
         "Dart",

--- a/src/exported_files/borders.pr
+++ b/src/exported_files/borders.pr
@@ -2,15 +2,15 @@ import 'package:flutter/material.dart';
 
 class AppBorders {
 
-{[ const borderTokensTree = @ds.tokenGroupTreeByType("Border") /]}
+{[ const borderTokensTree = ds.tokenGroupTreeByType("Border") /]}
 {[ traverse borderTokensTree property subgroups into borderTokenGroup ]}
-  {[ let fullTokenGroupPath = @js.createFullTokenGroupPath(borderTokenGroup) /]}
-  {[ const borderTokenInGroups = @ds.tokensByGroupId(borderTokenGroup.id) /]}
+  {[ let fullTokenGroupPath = createFullTokenGroupPath(borderTokenGroup) /]}
+  {[ const borderTokenInGroups = ds.tokensByGroupId(borderTokenGroup.id) /]}
   {[ for borderToken in borderTokenInGroups ]}
-  {[ const fullTokenPath = @js.arrayConcat(fullTokenGroupPath, borderToken.name) /]}
-  {[ const fullTokenName = @js.arrayJoin(fullTokenPath, " ").camelcased(false) /]}
-  {[ if @boolean.and(@compare.nonnull(borderToken.description), @boolean.not(@compare.equals(borderToken.description, ""))) ]}
-{{ @js.createDocumentationComment(borderToken.description, "  ") }}
+  {[ const fullTokenPath = arrayConcat(fullTokenGroupPath, borderToken.name) /]}
+  {[ const fullTokenName = arrayJoin(fullTokenPath, " ").camelcased(false) /]}
+  {[ if (borderToken.description && borderToken.description !== "") ]}
+{{ createDocumentationComment(borderToken.description, "  ") }}
   {[/]}
   static const {{ fullTokenName }} = Border.fromBorderSide(BorderSide(
     color: {[ inject "export_color_value" context borderToken.value.color /]},

--- a/src/exported_files/colors.pr
+++ b/src/exported_files/colors.pr
@@ -2,15 +2,15 @@ import 'package:flutter/material.dart';
 
 class AppColors {
 
-{[ const colorTokensTree = @ds.tokenGroupTreeByType("Color") /]}
+{[ const colorTokensTree = ds.tokenGroupTreeByType("Color") /]}
 {[ traverse colorTokensTree property subgroups into colorTokenGroup ]}
-  {[ let fullTokenGroupPath = @js.createFullTokenGroupPath(colorTokenGroup) /]}
-  {[ const colorTokenInGroups = @ds.tokensByGroupId(colorTokenGroup.id) /]}
+  {[ let fullTokenGroupPath = createFullTokenGroupPath(colorTokenGroup) /]}
+  {[ const colorTokenInGroups = ds.tokensByGroupId(colorTokenGroup.id) /]}
   {[ for colorToken in colorTokenInGroups ]}
-  {[ const fullTokenPath = @js.arrayConcat(fullTokenGroupPath, colorToken.name) /]}
-  {[ const fullTokenName = @js.arrayJoin(fullTokenPath, " ").camelcased(false) /]}
-  {[ if @boolean.and(@compare.nonnull(colorToken.description), @boolean.not(@compare.equals(colorToken.description, ""))) ]}
-{{ @js.createDocumentationComment(colorToken.description, "  ") }}
+  {[ const fullTokenPath = arrayConcat(fullTokenGroupPath, colorToken.name) /]}
+  {[ const fullTokenName = arrayJoin(fullTokenPath, " ").camelcased(false) /]}
+  {[ if (colorToken.description && colorToken.description !== "") ]}
+{{ createDocumentationComment(colorToken.description, "  ") }}
   {[/]}
   static const {{ fullTokenName }} = {[ inject "export_color_value" context colorToken.value /]}; 
   

--- a/src/exported_files/dimensions.pr
+++ b/src/exported_files/dimensions.pr
@@ -1,14 +1,14 @@
 class AppDimensions {
 
-{[ const measureTokensTree = @ds.tokenGroupTreeByType("Measure") /]}
+{[ const measureTokensTree = ds.tokenGroupTreeByType("Measure") /]}
 {[ traverse measureTokensTree property subgroups into measureTokenGroup ]}
-  {[ let fullTokenGroupPath = @js.createFullTokenGroupPath(measureTokenGroup) /]}
-  {[ const measureTokenInGroups = @ds.tokensByGroupId(measureTokenGroup.id) /]}
+  {[ let fullTokenGroupPath = createFullTokenGroupPath(measureTokenGroup) /]}
+  {[ const measureTokenInGroups = ds.tokensByGroupId(measureTokenGroup.id) /]}
   {[ for measureToken in measureTokenInGroups ]}
-  {[ const fullTokenPath = @js.arrayConcat(fullTokenGroupPath, measureToken.name) /]}
-  {[ const fullTokenName = @js.arrayJoin(fullTokenPath, " ").camelcased(false) /]}
-  {[ if @boolean.and(@compare.nonnull(measureToken.description), @boolean.not(@compare.equals(measureToken.description, ""))) ]}
-{{ @js.createDocumentationComment(measureToken.description, "  ") }}
+  {[ const fullTokenPath = arrayConcat(fullTokenGroupPath, measureToken.name) /]}
+  {[ const fullTokenName = arrayJoin(fullTokenPath, " ").camelcased(false) /]}
+  {[ if (measureToken.description && measureToken.description !== "") ]}
+{{ createDocumentationComment(measureToken.description, "  ") }}
   {[/]}
   static const {{ fullTokenName }} = {[ inject "export_measure_value" context measureToken.value /]};
 

--- a/src/exported_files/gradients.pr
+++ b/src/exported_files/gradients.pr
@@ -2,15 +2,15 @@ import 'package:flutter/material.dart';
 
 class AppGradients {
 
-{[ const gradientTokensTree = @ds.tokenGroupTreeByType("Gradient") /]}
+{[ const gradientTokensTree = ds.tokenGroupTreeByType("Gradient") /]}
 {[ traverse gradientTokensTree property subgroups into gradientTokenGroup ]}
-  {[ let fullTokenGroupPath = @js.createFullTokenGroupPath(gradientTokenGroup) /]}
-  {[ const gradientTokenInGroups = @ds.tokensByGroupId(gradientTokenGroup.id) /]}
+  {[ let fullTokenGroupPath = createFullTokenGroupPath(gradientTokenGroup) /]}
+  {[ const gradientTokenInGroups = ds.tokensByGroupId(gradientTokenGroup.id) /]}
   {[ for gradientToken in gradientTokenInGroups ]}
-  {[ const fullTokenPath = @js.arrayConcat(fullTokenGroupPath, gradientToken.name) /]}
-  {[ const fullTokenName = @js.arrayJoin(fullTokenPath, " ").camelcased(false) /]}
-  {[ if @boolean.and(@compare.nonnull(gradientToken.description), @boolean.not(@compare.equals(gradientToken.description, ""))) ]}
-{{ @js.createDocumentationComment(gradientToken.description, "  ") }}
+  {[ const fullTokenPath = arrayConcat(fullTokenGroupPath, gradientToken.name) /]}
+  {[ const fullTokenName = arrayJoin(fullTokenPath, " ").camelcased(false) /]}
+  {[ if (gradientToken.description && gradientToken.description !== "") ]}
+{{ createDocumentationComment(gradientToken.description, "  ") }}
   {[/]}
   {[ log gradientToken /]}
   static const {{ fullTokenName }} = LinearGradient(

--- a/src/exported_files/radii.pr
+++ b/src/exported_files/radii.pr
@@ -2,15 +2,15 @@ import 'package:flutter/material.dart';
 
 class AppRadii {
 
-{[ const radiusTokensTree = @ds.tokenGroupTreeByType("Radius") /]}
+{[ const radiusTokensTree = ds.tokenGroupTreeByType("Radius") /]}
 {[ traverse radiusTokensTree property subgroups into radiusTokenGroup ]}
-  {[ let fullTokenGroupPath = @js.createFullTokenGroupPath(radiusTokenGroup) /]}
-  {[ const radiusTokenInGroups = @ds.tokensByGroupId(radiusTokenGroup.id) /]}
+  {[ let fullTokenGroupPath = createFullTokenGroupPath(radiusTokenGroup) /]}
+  {[ const radiusTokenInGroups = ds.tokensByGroupId(radiusTokenGroup.id) /]}
   {[ for radiusToken in radiusTokenInGroups ]}
-  {[ const fullTokenPath = @js.arrayConcat(fullTokenGroupPath, radiusToken.name) /]}
-  {[ const fullTokenName = @js.arrayJoin(fullTokenPath, " ").camelcased(false) /]}
-  {[ if @boolean.and(@compare.nonnull(radiusToken.description), @boolean.not(@compare.equals(radiusToken.description, ""))) ]}
-{{ @js.createDocumentationComment(radiusToken.description, "  ") }}
+  {[ const fullTokenPath = arrayConcat(fullTokenGroupPath, radiusToken.name) /]}
+  {[ const fullTokenName = arrayJoin(fullTokenPath, " ").camelcased(false) /]}
+  {[ if (radiusToken.description && radiusToken.description !== "") ]}
+{{ createDocumentationComment(radiusToken.description, "  ") }}
   {[/]}
   static const {{ fullTokenName }} = BorderRadius.all(Radius.circular({[ inject "export_measure_value" context radiusToken.value.radius /]}));
 

--- a/src/exported_files/shadows.pr
+++ b/src/exported_files/shadows.pr
@@ -2,15 +2,15 @@ import 'package:flutter/material.dart';
 
 class AppShadows {
 
-{[ const shadowTokensTree = @ds.tokenGroupTreeByType("Shadow") /]}
+{[ const shadowTokensTree = ds.tokenGroupTreeByType("Shadow") /]}
 {[ traverse shadowTokensTree property subgroups into shadowTokenGroup ]}
-  {[ let fullTokenGroupPath = @js.createFullTokenGroupPath(shadowTokenGroup) /]}
-  {[ const shadowTokenInGroups = @ds.tokensByGroupId(shadowTokenGroup.id) /]}
+  {[ let fullTokenGroupPath = createFullTokenGroupPath(shadowTokenGroup) /]}
+  {[ const shadowTokenInGroups = ds.tokensByGroupId(shadowTokenGroup.id) /]}
   {[ for shadowToken in shadowTokenInGroups ]}
-  {[ const fullTokenPath = @js.arrayConcat(fullTokenGroupPath, shadowToken.name) /]}
-  {[ const fullTokenName = @js.arrayJoin(fullTokenPath, " ").camelcased(false) /]}
-  {[ if @boolean.and(@compare.nonnull(shadowToken.description), @boolean.not(@compare.equals(shadowToken.description, ""))) ]}
-{{ @js.createDocumentationComment(shadowToken.description, "  ") }}
+  {[ const fullTokenPath = arrayConcat(fullTokenGroupPath, shadowToken.name) /]}
+  {[ const fullTokenName = arrayJoin(fullTokenPath, " ").camelcased(false) /]}
+  {[ if (shadowToken.description && shadowToken.description !== "") ]}
+{{ createDocumentationComment(shadowToken.description, "  ") }}
   {[/]}
   static const {{ fullTokenName }} = BoxShadow(
     color: {[ inject "export_color_value" context shadowToken.value.color /]},

--- a/src/exported_files/text_styles.pr
+++ b/src/exported_files/text_styles.pr
@@ -2,15 +2,15 @@ import 'package:flutter/material.dart';
 
 class AppTextStyles {
 
-{[ const typographyTokensTree = @ds.tokenGroupTreeByType("Typography") /]}
+{[ const typographyTokensTree = ds.tokenGroupTreeByType("Typography") /]}
 {[ traverse typographyTokensTree property subgroups into typographyTokenGroup ]}
-  {[ let fullTokenGroupPath = @js.createFullTokenGroupPath(typographyTokenGroup) /]}
-  {[ const typographyTokenInGroups = @ds.tokensByGroupId(typographyTokenGroup.id) /]}
+  {[ let fullTokenGroupPath = createFullTokenGroupPath(typographyTokenGroup) /]}
+  {[ const typographyTokenInGroups = ds.tokensByGroupId(typographyTokenGroup.id) /]}
   {[ for typographyToken in typographyTokenInGroups ]}
-  {[ const fullTokenPath = @js.arrayConcat(fullTokenGroupPath, typographyToken.name) /]}
-  {[ const fullTokenName = @js.arrayJoin(fullTokenPath, " ").camelcased(false) /]}
+  {[ const fullTokenPath = arrayConcat(fullTokenGroupPath, typographyToken.name) /]}
+  {[ const fullTokenName = arrayJoin(fullTokenPath, " ").camelcased(false) /]}
   {[ let fontStyle = "normal" /]}
-  {[ if @ds.fonts.isItalic(typographyToken.value.font) ]}
+  {[ if ds.isFontItalic(typographyToken.value.font) ]}
     {[ set fontStyle = "italic" /]}
   {[/]}
   {[ let decoration = "none" /]}
@@ -25,14 +25,14 @@ class AppTextStyles {
   {[ let letterSpacing = typographyToken.value.letterSpacing.measure /]}
   {[ if typographyToken.value.letterSpacing.unit.equals("Percent") ]}
     {[ const fontSize = typographyToken.value.fontSize.measure /]}
-    {[ set letterSpacing = fontSize.dividedBy(100).multipliedBy(letterSpacing) /]}
+    {[ set letterSpacing = (fontSize / 100 * letterSpacing) /]}
   {[/]}
-  {[ if @boolean.and(@compare.nonnull(typographyToken.description), @boolean.not(@compare.equals(typographyToken.description, ""))) ]}
-{{ @js.createDocumentationComment(typographyToken.description, "  ") }}
+  {[ if (typographyToken.description && typographyToken.description !== "") ]}
+{{ createDocumentationComment(typographyToken.description, "  ") }}
   {[/]}
   static const {{ fullTokenName }} = TextStyle(
     fontFamily: "{{ typographyToken.value.font.family }}",
-    fontWeight: FontWeight.w{{ @ds.fonts.weight(typographyToken.value.font) }},
+    fontWeight: FontWeight.w{{ ds.fontWeight(typographyToken.value.font) }},
     fontStyle: FontStyle.{{ fontStyle }},
     fontSize: {[ inject "export_measure_value" context typographyToken.value.fontSize /]},
     decoration: TextDecoration.{{ decoration }},

--- a/src/utilities/export_point.pr
+++ b/src/utilities/export_point.pr
@@ -1,1 +1,1 @@
-Alignment({{ context.x.subtractedBy(0.5).multipliedBy(2) }}, {{ context.y.subtractedBy(0.5).multipliedBy(2) }})
+Alignment({{ (context.x - 0.5) * 2 }}, {{ (context.y - 0.5) * 2 }})

--- a/src/utilities/export_token_description.pr
+++ b/src/utilities/export_token_description.pr
@@ -1,3 +1,3 @@
-{[ if @boolean.and(@compare.nonnull(context.description), @boolean.not(@compare.equals(context.description, ""))) ]}
-{{ @js.createDocumentationComment(context.description, "  ") }}
+{[ if (context.description && context.description !== "") ]}
+{{ createDocumentationComment(context.description, "  ") }}
 {[/]}

--- a/src/utilities/export_token_name.pr
+++ b/src/utilities/export_token_name.pr
@@ -1,4 +1,4 @@
-{[ if @compare.nonnull(originStyle) ]}
+{[ if originStyle ]}
 {{ originStyle.name.replacing("/", " ").camelcased(false) }}
 {[ else ]}
 {{ meta.name.replacing("/", " ").camelcased(false) }}


### PR DESCRIPTION
This PR adds support for Pulsar 1.5

- All javascript calls now treated as top-level functions (no more `@js.` needed and will throw error if used) so all are reworked
- DS accessors are now proper methods on top-level `ds` object, so everything was reworked for this and autocomplete now properly works for those as well
- All ds methods are now actual methods, and can't have extra `.` inside it, so that was removed (for example, `@ds.fonts.isItalic` is now actually `ds.isFontItalic()`)
- Expressions have been simplified and syntax reworked to be aligned with new Pulsar, which follows JS syntax closely now
- Complex expressions inside flows must be surrounded with `()`, but expressions inside `{{ }}` don't need this, so reworked as well
- Added shorthands and object support, so you can use `{}` and `[]` to create empty objects and arrays, and all methods used previously to init etc. were removed
- `self` is `this` to align with javascript, and `self` is no longer available as global property

- Version of exporter bumped to next minor


Note for reviewer:
This PR CAN'T be merged and exporter run before Pulsar is merged to your environments, please don't merge it yourself.