### PR TITLE
Enh: add border sides export

### DIFF
--- a/output.json
+++ b/output.json
@@ -5,6 +5,10 @@
             "write_to": "borders.dart"
         },
         {
+            "invoke": "border_sides.pr",
+            "write_to": "border_sides.dart"
+        },
+        {
             "invoke": "colors.pr",
             "write_to": "colors.dart"
         },

--- a/src/exported_files/border_sides.pr
+++ b/src/exported_files/border_sides.pr
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class AppBorderSides {
+
+{[ let brand = ds.currentBrand() /]}
+{[ const borderTokensTree = ds.tokenGroupTreeByType("Border", brand.id) /]}
+{[ traverse borderTokensTree property subgroups into borderTokenGroup ]}
+  {[ let fullTokenGroupPath = createFullTokenGroupPath(borderTokenGroup) /]}
+  {[ const borderTokenInGroups = ds.tokensByGroupId(borderTokenGroup.id) /]}
+  {[ for borderToken in borderTokenInGroups ]}
+  {[ const fullTokenPath = arrayConcat(fullTokenGroupPath, borderToken.name) /]}
+  {[ const fullTokenName = arrayJoin(fullTokenPath, " ").camelcased(false) /]}
+  {[ if (borderToken.description && borderToken.description !== "") ]}
+{{ createDocumentationComment(borderToken.description, "  ") }}
+  {[/]}
+  static const {{ fullTokenName }} = BorderSide(
+    color: {[ inject "export_color_value" context borderToken.value.color /]},
+    width: {[ inject "export_measure_value" context borderToken.value.width /]},
+  );
+
+  {[/]}
+{[/]}
+  AppBorderSides._();
+}


### PR DESCRIPTION
### Changes

- Added export of all border token as `BorderSide` instances in addition to `Border` allowing using exported tokens with things like text field input borders